### PR TITLE
Feature/emulator deployment

### DIFF
--- a/resources/emulators/lights/Dockerfile.prod
+++ b/resources/emulators/lights/Dockerfile.prod
@@ -1,5 +1,10 @@
 FROM python:3
 
+ENV LIGHT_CONTROLLER=simulator
+ENV APP_PORT=80
+ENV APP_HOST=0.0.0.0
+ENV APP_DEBUG=False
+
 RUN apt-get update && apt-get install -y ca-certificates
 
 COPY  ./src/light_controller /app

--- a/resources/emulators/lights/Dockerfile.prod
+++ b/resources/emulators/lights/Dockerfile.prod
@@ -1,0 +1,14 @@
+FROM python:3
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+COPY  ./src/light_controller /app
+COPY requirements.txt /app
+
+WORKDIR /app
+RUN pip install -r requirements.txt
+ENTRYPOINT ["python"]
+
+EXPOSE 80
+
+CMD ["server.py"]

--- a/resources/emulators/lights/app-compose.yaml
+++ b/resources/emulators/lights/app-compose.yaml
@@ -1,6 +1,6 @@
 version: "2"
 services:
-  go-web-app:
+  web-app:
     restart: always
     build:
       dockerfile: Dockerfile.prod

--- a/resources/emulators/lights/app-compose.yaml
+++ b/resources/emulators/lights/app-compose.yaml
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  go-web-app:
+    restart: always
+    build:
+      dockerfile: Dockerfile.prod
+      context: .
+    environment:
+      - VIRTUAL_HOST=lights.ciart.live
+      - LETSENCRYPT_HOST=lights.ciart.live

--- a/resources/emulators/lights/nginx-proxy-compose.yaml
+++ b/resources/emulators/lights/nginx-proxy-compose.yaml
@@ -1,0 +1,22 @@
+version: "2"
+
+services:
+  nginx-proxy:
+    restart: always
+    image: jwilder/nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/etc/nginx/vhost.d"
+      - "/usr/share/nginx/html"
+      - "/var/run/docker.sock:/tmp/docker.sock:ro"
+      - "/etc/nginx/certs"
+
+  letsencrypt-nginx-proxy-companion:
+    restart: always
+    image: jrcs/letsencrypt-nginx-proxy-companion
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    volumes_from:
+      - "nginx-proxy"


### PR DESCRIPTION
Add configuration to run light emulator on production server.

Emulator available at: [lights.ciart.live](https://lights.ciart.live)